### PR TITLE
fix: remove tratamento automático de 403 no interceptor

### DIFF
--- a/src/app/services/auth.interceptor.ts
+++ b/src/app/services/auth.interceptor.ts
@@ -34,14 +34,8 @@ export class AuthInterceptor implements HttpInterceptor {
     
     return next.handle(clonedRequest).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 403) {
-          // Token inválido ou expirado - fazer logout automático
-          console.warn('Token inválido (403) - redirecionando para login');
-          this.authService.logout();
-          this.router.navigate(['/login'], { 
-            queryParams: { sessionExpired: 'true' }
-          });
-        }
+        // Removido tratamento automático de 403 que estava impedindo recuperação de senha
+        // O tratamento de erro deve ser feito nos componentes específicos
         return throwError(() => error);
       })
     );


### PR DESCRIPTION
- Remove logout automático em erro 403 que estava impedindo recuperação de senha
- Mantém interceptor para adicionar headers (token e tenant)
- Tratamento de erro 403 deve ser feito nos componentes específicos quando necessário
- Permite que fluxo de recuperação de senha funcione corretamente